### PR TITLE
test: comprehensive test suite for resume tailoring service

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -14,7 +14,7 @@ module.exports = {
       '<rootDir>/__mocks__/fileMock.js',
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  testPathIgnorePatterns: ['node_modules', 'dist', 'src/tests/e2e'],
+  testPathIgnorePatterns: ['node_modules', 'dist', 'src/tests/e2e', 'src/tests/resume'],
   transformIgnorePatterns: ['node_modules/'],
   setupFilesAfterEnv: ['<rootDir>/setup-test-env.js'],
   moduleDirectories: ['node_modules', '<rootDir>/src']

--- a/jest.resume.config.cjs
+++ b/jest.resume.config.cjs
@@ -1,0 +1,20 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  // Resume services are Node.js code — not browser code — so use 'node', not 'jsdom'
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: './tsconfig.resume.json',
+    }],
+  },
+  testRegex: 'src/tests/resume/.*\\.test\\.ts$',
+  moduleNameMapper: {
+    // Resolve .js extension imports to .ts (NodeNext module resolution compatibility)
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  testPathIgnorePatterns: ['node_modules', 'dist'],
+  transformIgnorePatterns: ['/node_modules/'],
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:e2e": "jest --config jest.e2e.config.ts",
-    "prebuild": "npm test"
+    "prebuild": "npm test",
+    "test:resume": "jest --config jest.resume.config.cjs"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/src/tests/resume/llmValidator.test.ts
+++ b/src/tests/resume/llmValidator.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for LLMValidator
+ * Covers: parseValidationResponse (via validateResume) — JSON parsing,
+ * code block stripping, issue/warning normalization, all error fallback paths
+ */
+
+import { LLMValidator, ValidationResult } from '../../resume/services/llmValidator';
+import { OllamaService } from '../../resume/services/ollamaService';
+import { SimpleProfile } from '../../resume/services/profileDataAdapter';
+import { TailoredResumeResult } from '../../resume/services/resumeTailoringEngine';
+
+// Suppress console.error: LLMValidator logs on parse failures as expected
+// behavior. Tests exercising those paths would produce noisy output otherwise.
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ─── Test Fixtures ────────────────────────────────────────────────────────────
+
+const mockProfile: SimpleProfile = {
+  name: 'Hank Hill',
+  email: 'hank@strickland.com',
+  phone: '555-0100',
+  location: 'Arlen, TX',
+  linkedin: 'https://linkedin.com/in/hankhill',
+  github: 'https://github.com/hankhill',
+  website: 'https://hankhill.dev',
+  summary: 'Expert propane and software engineer.',
+  workHistory: [
+    {
+      company: 'Strickland Propane',
+      role: 'Assistant Manager',
+      duration: 'January 2000 - Present',
+      location: 'Arlen, TX',
+      achievements: ['Managed propane sales', 'Led team of 5'],
+    },
+  ],
+};
+
+const mockTailored: TailoredResumeResult = {
+  summary: 'Tailored summary',
+  matchScore: 85,
+  reasoning: 'Good fit',
+  selectedExperiences: [
+    {
+      company: 'Strickland Propane',
+      role: 'Assistant Manager',
+      duration: 'January 2000 - Present',
+      location: 'Arlen, TX',
+      selectedAchievements: ['Managed propane sales'],
+    },
+  ],
+  relevantSkills: ['Leadership', 'TypeScript'],
+};
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function makeValidator(chatResponse: string): LLMValidator {
+  const mockOllama = {
+    chat: jest.fn().mockResolvedValue(chatResponse),
+  } as unknown as OllamaService;
+  return new LLMValidator(mockOllama);
+}
+
+async function validate(chatResponse: string): Promise<ValidationResult> {
+  return makeValidator(chatResponse).validateResume(mockProfile, mockTailored);
+}
+
+// ─── Construction ────────────────────────────────────────────────────────────
+
+describe('LLMValidator — construction', () => {
+  it('constructs without throwing', () => {
+    const mockOllama = { chat: jest.fn() } as unknown as OllamaService;
+    expect(() => new LLMValidator(mockOllama)).not.toThrow();
+  });
+
+  it('calls ollama.chat() when validateResume() is invoked', async () => {
+    const chat = jest.fn().mockResolvedValue('{"isValid":true,"issues":[],"warnings":[],"confidence":90}');
+    const mockOllama = { chat } as unknown as OllamaService;
+    const validator = new LLMValidator(mockOllama);
+    await validator.validateResume(mockProfile, mockTailored);
+    expect(chat).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── parseValidationResponse — happy paths ───────────────────────────────────
+
+describe('LLMValidator — parseValidationResponse (via validateResume)', () => {
+  it('returns isValid:true when issues array is empty', async () => {
+    const result = await validate('{"isValid":true,"issues":[],"warnings":[],"confidence":95}');
+    expect(result.isValid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('returns isValid:false when issues array is non-empty', async () => {
+    const result = await validate('{"isValid":false,"issues":["Fake company added"],"warnings":[],"confidence":90}');
+    expect(result.isValid).toBe(false);
+    expect(result.issues).toContain('Fake company added');
+  });
+
+  it('parses confidence value correctly', async () => {
+    const result = await validate('{"isValid":true,"issues":[],"warnings":[],"confidence":77}');
+    expect(result.confidence).toBe(77);
+  });
+
+  it('strips ```json code block markers', async () => {
+    const json = '{"isValid":true,"issues":[],"warnings":[],"confidence":80}';
+    const result = await validate('```json\n' + json + '\n```');
+    expect(result.isValid).toBe(true);
+    expect(result.confidence).toBe(80);
+  });
+
+  it('strips ``` code block markers', async () => {
+    const json = '{"isValid":true,"issues":[],"warnings":[],"confidence":70}';
+    const result = await validate('```\n' + json + '\n```');
+    expect(result.isValid).toBe(true);
+    expect(result.confidence).toBe(70);
+  });
+
+  it('extracts JSON embedded in surrounding text', async () => {
+    const result = await validate('Here is my validation: {"isValid":true,"issues":[],"warnings":[],"confidence":60} End.');
+    expect(result.isValid).toBe(true);
+  });
+});
+
+// ─── Issue normalization ──────────────────────────────────────────────────────
+
+describe('LLMValidator — issue normalization', () => {
+  it('handles issues as plain strings', async () => {
+    const result = await validate('{"isValid":false,"issues":["Company mismatch"],"warnings":[],"confidence":85}');
+    expect(result.issues[0]).toBe('Company mismatch');
+  });
+
+  it('handles issues as objects with .issue field, prefixed with company and role', async () => {
+    const issueObj = { company: 'Acme', role: 'Engineer', issue: 'Role not found' };
+    const result = await validate(JSON.stringify({
+      isValid: false,
+      issues: [issueObj],
+      warnings: [],
+      confidence: 80,
+    }));
+    expect(result.issues[0]).toContain('Acme');
+    expect(result.issues[0]).toContain('Engineer');
+    expect(result.issues[0]).toContain('Role not found');
+  });
+
+  it('handles issues as objects without .issue field via JSON.stringify fallback', async () => {
+    const result = await validate(JSON.stringify({
+      isValid: false,
+      issues: [{ unknown: 'structure' }],
+      warnings: [],
+      confidence: 75,
+    }));
+    expect(result.issues[0]).toContain('unknown');
+  });
+
+  it('filters out "No issues found" strings from issues array', async () => {
+    const result = await validate(JSON.stringify({
+      isValid: true,
+      issues: ['No issues found'],
+      warnings: [],
+      confidence: 90,
+    }));
+    expect(result.issues).toHaveLength(0);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('respects explicit isValid:false even with empty issues after filtering', async () => {
+    // When parsed.isValid is explicitly false, result should be false
+    const result = await validate(JSON.stringify({
+      isValid: false,
+      issues: [],
+      warnings: [],
+      confidence: 50,
+    }));
+    expect(result.isValid).toBe(false);
+  });
+});
+
+// ─── Warning normalization ────────────────────────────────────────────────────
+
+describe('LLMValidator — warning normalization', () => {
+  it('handles warnings as strings', async () => {
+    const result = await validate('{"isValid":true,"issues":[],"warnings":["Minor format difference"],"confidence":90}');
+    expect(result.warnings[0]).toBe('Minor format difference');
+  });
+
+  it('handles warnings as objects (stringified)', async () => {
+    const result = await validate(JSON.stringify({
+      isValid: true,
+      issues: [],
+      warnings: [{ code: 'W001', message: 'date format' }],
+      confidence: 85,
+    }));
+    expect(result.warnings[0]).toContain('W001');
+  });
+
+  it('returns empty warnings array when warnings missing from response', async () => {
+    const result = await validate('{"isValid":true,"issues":[],"confidence":90}');
+    expect(result.warnings).toEqual([]);
+  });
+});
+
+// ─── Error fallbacks ──────────────────────────────────────────────────────────
+
+describe('LLMValidator — error fallbacks', () => {
+  it('defaults confidence to 50 when confidence is not a number', async () => {
+    const result = await validate('{"isValid":true,"issues":[],"warnings":[],"confidence":"high"}');
+    expect(result.confidence).toBe(50);
+  });
+
+  it('returns isValid:true with warning when JSON parse fails entirely', async () => {
+    const result = await validate('This is not JSON at all, completely unparseable text.');
+    expect(result.isValid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain('Failed to parse');
+  });
+
+  it('returns isValid:true with warning when no JSON object found in response', async () => {
+    const result = await validate('["array", "not", "object"]');
+    expect(result.isValid).toBe(true);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('returns confidence 50 in fallback path', async () => {
+    const result = await validate('unparseable');
+    expect(result.confidence).toBe(50);
+  });
+});

--- a/src/tests/resume/ollamaService.test.ts
+++ b/src/tests/resume/ollamaService.test.ts
@@ -6,6 +6,17 @@
 
 import { OllamaService } from '../../resume/services/ollamaService';
 
+// Suppress console.error: source code logs on error paths (network failures,
+// parse failures) as expected behavior. Tests that exercise those paths would
+// produce noisy output without this suppression.
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 // Helper to capture the fetch body sent during chat()
 // Uses jest.spyOn so restoreAllMocks() cleans it up automatically.
 async function chatAndCaptureBody(service: OllamaService): Promise<Record<string, unknown>> {
@@ -96,6 +107,15 @@ describe('OllamaService.forTask()', () => {
 // ─── isAvailable() ────────────────────────────────────────────────────────────
 
 describe('OllamaService.isAvailable()', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runAllTimers();
+    jest.useRealTimers();
+  });
+
   it('returns true when fetch responds ok', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
     const svc = new OllamaService();

--- a/src/tests/resume/ollamaService.test.ts
+++ b/src/tests/resume/ollamaService.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for OllamaService
+ * Covers: constructor defaults, model alias resolution, forTask() routing,
+ * isAvailable(), chat(), extractJobKeywords() JSON parsing
+ */
+
+import { OllamaService } from '../../resume/services/ollamaService';
+
+// Helper to capture the fetch body sent during chat()
+// Uses jest.spyOn so restoreAllMocks() cleans it up automatically.
+async function chatAndCaptureBody(service: OllamaService): Promise<Record<string, unknown>> {
+  jest.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      model: 'test',
+      created_at: '',
+      message: { role: 'assistant', content: 'ok' },
+      done: true,
+    }),
+  } as Response);
+  await service.chat([{ role: 'user', content: 'test' }]);
+  const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+  return JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ─── Constructor ──────────────────────────────────────────────────────────────
+
+describe('OllamaService — constructor', () => {
+  it('uses default model qwen3:14b when no config provided', async () => {
+    const svc = new OllamaService();
+    const body = await chatAndCaptureBody(svc);
+    expect(body.model).toBe('qwen3:14b');
+  });
+
+  it('accepts custom baseUrl without throwing', () => {
+    expect(() => new OllamaService({ baseUrl: 'http://localhost:11434' })).not.toThrow();
+  });
+
+  it('accepts custom model string', async () => {
+    const svc = new OllamaService({ model: 'llama3:8b' });
+    const body = await chatAndCaptureBody(svc);
+    expect(body.model).toBe('llama3:8b');
+  });
+});
+
+// ─── Model Alias Resolution ───────────────────────────────────────────────────
+
+describe('OllamaService — model alias resolution', () => {
+  const cases: [string, string][] = [
+    ['qwen3',    'qwen3:14b'],
+    ['qwen2',    'qwen2.5:14b'],
+    ['deepseek', 'deepseek-r1:14b'],
+    ['fast',     'qwen2.5:7b'],
+    ['qwen3-8b', 'qwen3:8b'],
+  ];
+
+  test.each(cases)('resolves alias "%s" → "%s"', async (alias, expected) => {
+    const svc = new OllamaService({ model: alias });
+    const body = await chatAndCaptureBody(svc);
+    expect(body.model).toBe(expected);
+  });
+
+  it('passes through unknown model names unchanged', async () => {
+    const svc = new OllamaService({ model: 'llama3:70b' });
+    const body = await chatAndCaptureBody(svc);
+    expect(body.model).toBe('llama3:70b');
+  });
+});
+
+// ─── forTask() ────────────────────────────────────────────────────────────────
+
+describe('OllamaService.forTask()', () => {
+  const taskExpected: [Parameters<typeof OllamaService.forTask>[0], string][] = [
+    ['analyze',      'qwen3:14b'],
+    ['tailor',       'qwen3:14b'],
+    ['cover-letter', 'deepseek-r1:14b'],
+    ['validate',     'qwen2.5:14b'],
+    ['score',        'qwen2.5:14b'],
+  ];
+
+  test.each(taskExpected)('task "%s" uses model "%s"', async (task, expectedModel) => {
+    const svc = OllamaService.forTask(task);
+    const body = await chatAndCaptureBody(svc);
+    expect(body.model).toBe(expectedModel);
+  });
+
+  it('returns an OllamaService instance', () => {
+    expect(OllamaService.forTask('analyze')).toBeInstanceOf(OllamaService);
+  });
+});
+
+// ─── isAvailable() ────────────────────────────────────────────────────────────
+
+describe('OllamaService.isAvailable()', () => {
+  it('returns true when fetch responds ok', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    const svc = new OllamaService();
+    expect(await svc.isAvailable()).toBe(true);
+  });
+
+  it('returns false when response.ok is false', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({ ok: false } as Response);
+    const svc = new OllamaService();
+    expect(await svc.isAvailable()).toBe(false);
+  });
+
+  it('returns false when fetch throws', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    const svc = new OllamaService();
+    expect(await svc.isAvailable()).toBe(false);
+  });
+});
+
+// ─── chat() ──────────────────────────────────────────────────────────────────
+
+describe('OllamaService.chat()', () => {
+  const mockOkResponse = (content: string) => ({
+    ok: true,
+    json: async () => ({
+      model: 'test',
+      created_at: '',
+      message: { role: 'assistant', content },
+      done: true,
+    }),
+  } as Response);
+
+  it('returns message.content from successful response', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(mockOkResponse('Hello from Ollama'));
+    const svc = new OllamaService();
+    const result = await svc.chat([{ role: 'user', content: 'hi' }]);
+    expect(result).toBe('Hello from Ollama');
+  });
+
+  it('sends POST to /api/chat', async () => {
+    const spy = jest.spyOn(global, 'fetch').mockResolvedValue(mockOkResponse('ok'));
+    const svc = new OllamaService();
+    await svc.chat([{ role: 'user', content: 'hi' }]);
+    expect(spy.mock.calls[0][0]).toMatch(/\/api\/chat$/);
+    expect((spy.mock.calls[0][1] as RequestInit).method).toBe('POST');
+  });
+
+  it('sends messages and stream:false in body', async () => {
+    const spy = jest.spyOn(global, 'fetch').mockResolvedValue(mockOkResponse('ok'));
+    const svc = new OllamaService();
+    const messages = [{ role: 'system' as const, content: 'sys' }, { role: 'user' as const, content: 'hello' }];
+    await svc.chat(messages);
+    const body = JSON.parse((spy.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.messages).toEqual(messages);
+    expect(body.stream).toBe(false);
+  });
+
+  it('throws when response is not ok', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      statusText: 'Internal Server Error',
+    } as Response);
+    const svc = new OllamaService();
+    await expect(svc.chat([{ role: 'user', content: 'hi' }])).rejects.toThrow('Ollama API error');
+  });
+
+  it('throws when fetch itself throws', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('Network down'));
+    const svc = new OllamaService();
+    await expect(svc.chat([{ role: 'user', content: 'hi' }])).rejects.toThrow('Network down');
+  });
+});
+
+// ─── extractJobKeywords() ─────────────────────────────────────────────────────
+
+describe('OllamaService.extractJobKeywords()', () => {
+  const validKeywords = {
+    skills: ['TypeScript', 'React'],
+    qualifications: ['5 years experience'],
+    responsibilities: ['Lead team'],
+    tools: ['JIRA'],
+  };
+
+  function mockChatResponse(content: string) {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        model: 'test', created_at: '', done: true,
+        message: { role: 'assistant', content },
+      }),
+    } as Response);
+  }
+
+  it('parses plain JSON response', async () => {
+    mockChatResponse(JSON.stringify(validKeywords));
+    const svc = new OllamaService();
+    const result = await svc.extractJobKeywords('some job posting');
+    expect(result).toEqual(validKeywords);
+  });
+
+  it('parses JSON wrapped in ```json code block', async () => {
+    mockChatResponse('```json\n' + JSON.stringify(validKeywords) + '\n```');
+    const svc = new OllamaService();
+    const result = await svc.extractJobKeywords('some job posting');
+    expect(result).toEqual(validKeywords);
+  });
+
+  it('parses JSON wrapped in ``` code block', async () => {
+    mockChatResponse('```\n' + JSON.stringify(validKeywords) + '\n```');
+    const svc = new OllamaService();
+    const result = await svc.extractJobKeywords('some job posting');
+    expect(result).toEqual(validKeywords);
+  });
+
+  it('returns empty structure when JSON parse fails', async () => {
+    mockChatResponse('This is not JSON at all.');
+    const svc = new OllamaService();
+    const result = await svc.extractJobKeywords('some job posting');
+    expect(result).toEqual({ skills: [], qualifications: [], responsibilities: [], tools: [] });
+  });
+
+  it('returns arrays for all four fields', async () => {
+    mockChatResponse(JSON.stringify(validKeywords));
+    const svc = new OllamaService();
+    const result = await svc.extractJobKeywords('job');
+    expect(Array.isArray(result.skills)).toBe(true);
+    expect(Array.isArray(result.qualifications)).toBe(true);
+    expect(Array.isArray(result.responsibilities)).toBe(true);
+    expect(Array.isArray(result.tools)).toBe(true);
+  });
+});

--- a/src/tests/resume/profileDataAdapter.test.ts
+++ b/src/tests/resume/profileDataAdapter.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for profileDataAdapter
+ * Covers: getProfileForResume() with mocked fs + profileData,
+ * calculateYearsOfExperience (via getProfileForResume), getProfileAsText()
+ */
+
+import * as fs from 'fs';
+
+// Mock fs before any imports that use it
+jest.mock('fs');
+
+// Mock profileData — the actual module uses import from '../../data/profileData.js'
+// With the .js→no-extension moduleNameMapper, this resolves to profileData.ts
+jest.mock('../../data/profileData', () => ({
+  profileData: {
+    linkedin: 'https://linkedin.com/in/testuser',
+    github: 'https://github.com/testuser',
+    workHistory: [
+      {
+        company: 'Test Corp',
+        role: 'Senior Engineer',
+        duration: 'January 2020 - Present',
+        description: [
+          { moreInfo: ['Built the thing', 'Fixed the other thing'] },
+        ],
+      },
+      {
+        company: 'Old Corp',
+        role: 'Junior Developer',
+        duration: 'January 2007 - December 2019',
+        description: [
+          { moreInfo: ['Wrote tests', 'Deployed code'] },
+        ],
+      },
+    ],
+  },
+}));
+
+import { getProfileForResume, getProfileAsText, SimpleProfile } from '../../resume/services/profileDataAdapter';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const validContact = {
+  name: 'Hank Hill',
+  email: 'hank@strickland.com',
+  phone: '555-0100',
+  location: 'Arlen, TX',
+  website: 'https://hankhill.dev',
+};
+
+// Freeze time: January 1, 2026
+// January 2007 start → ~19 years of experience
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+function mockFsWithContact(contact: object) {
+  (fs.existsSync as jest.Mock).mockReturnValue(true);
+  (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(contact));
+}
+
+// ─── getProfileForResume() — contact.json errors ──────────────────────────────
+
+describe('getProfileForResume() — contact.json errors', () => {
+  it('throws descriptive error when contact.json does not exist', () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    expect(() => getProfileForResume()).toThrow('contact.json not found');
+  });
+
+  it('throws error listing missing fields when contact.json is incomplete', () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ name: 'Hank' }));
+    expect(() => getProfileForResume()).toThrow(/missing required fields/i);
+  });
+
+  it('error message mentions at least one missing field name', () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ name: 'Hank' }));
+    try {
+      getProfileForResume();
+    } catch (e: unknown) {
+      expect((e as Error).message).toMatch(/email|phone|location|website/);
+    }
+  });
+});
+
+// ─── getProfileForResume() — happy path ──────────────────────────────────────
+
+describe('getProfileForResume() — happy path', () => {
+  beforeEach(() => mockFsWithContact(validContact));
+
+  it('returns an object with all SimpleProfile fields', () => {
+    const profile = getProfileForResume();
+    const requiredFields: (keyof SimpleProfile)[] = [
+      'name', 'email', 'phone', 'location',
+      'linkedin', 'github', 'website', 'summary', 'workHistory',
+    ];
+    requiredFields.forEach(field => {
+      expect(profile).toHaveProperty(field);
+    });
+  });
+
+  it('returns correct name from contact.json', () => {
+    expect(getProfileForResume().name).toBe('Hank Hill');
+  });
+
+  it('returns correct email from contact.json', () => {
+    expect(getProfileForResume().email).toBe('hank@strickland.com');
+  });
+
+  it('returns linkedin from profileData fallback', () => {
+    expect(getProfileForResume().linkedin).toBe('https://linkedin.com/in/testuser');
+  });
+
+  it('returns github from profileData fallback', () => {
+    expect(getProfileForResume().github).toBe('https://github.com/testuser');
+  });
+
+  it('returns 2 work history entries matching mock data', () => {
+    const profile = getProfileForResume();
+    expect(profile.workHistory).toHaveLength(2);
+    expect(profile.workHistory[0].company).toBe('Test Corp');
+    expect(profile.workHistory[1].company).toBe('Old Corp');
+  });
+
+  it('flattens nested description.moreInfo arrays into flat achievements', () => {
+    const profile = getProfileForResume();
+    const firstJob = profile.workHistory[0];
+    expect(firstJob.achievements).toContain('Built the thing');
+    expect(firstJob.achievements).toContain('Fixed the other thing');
+    expect(Array.isArray(firstJob.achievements)).toBe(true);
+  });
+
+  it('summary contains years of experience as a number', () => {
+    const profile = getProfileForResume();
+    // With frozen time at 2026-01-01 and start date Jan 2007 → ~19 years
+    expect(profile.summary).toMatch(/\d+\+?\s*years/i);
+  });
+});
+
+// ─── calculateYearsOfExperience (tested via getProfileForResume) ─────────────
+
+describe('calculateYearsOfExperience — via getProfileForResume()', () => {
+  beforeEach(() => mockFsWithContact(validContact));
+
+  it('calculates ~19 years from January 2007 with time frozen at 2026-01-01', () => {
+    // The summary includes the years value — extract it
+    const profile = getProfileForResume();
+    const match = profile.summary.match(/(\d+)\+?\s*years/i);
+    expect(match).not.toBeNull();
+    const years = parseInt(match![1]);
+    // Jan 2007 to Jan 2026 = 19 years exactly
+    expect(years).toBeGreaterThanOrEqual(18);
+    expect(years).toBeLessThanOrEqual(20);
+  });
+
+  it('produces a different (higher) year count than if work history started in 2015', () => {
+    // Verify that earliest date across multiple entries is used
+    // Our fixture has Jan 2007 — earlier than Jan 2020 — so count should reflect 2007
+    const profile = getProfileForResume();
+    const match = profile.summary.match(/(\d+)\+?\s*years/i);
+    const years = parseInt(match![1]);
+    // If only the 2020 entry was used, years would be ~6; should be ~19
+    expect(years).toBeGreaterThan(10);
+  });
+});
+
+// ─── getProfileAsText() ──────────────────────────────────────────────────────
+
+describe('getProfileAsText()', () => {
+  beforeEach(() => mockFsWithContact(validContact));
+
+  it('returns a non-empty string', () => {
+    const text = getProfileAsText();
+    expect(typeof text).toBe('string');
+    expect(text.length).toBeGreaterThan(0);
+  });
+
+  it('contains the candidate name', () => {
+    expect(getProfileAsText()).toContain('Hank Hill');
+  });
+
+  it('contains a Work History section header', () => {
+    expect(getProfileAsText()).toMatch(/work history/i);
+  });
+
+  it('contains each company name', () => {
+    const text = getProfileAsText();
+    expect(text).toContain('Test Corp');
+    expect(text).toContain('Old Corp');
+  });
+
+  it('contains email', () => {
+    expect(getProfileAsText()).toContain('hank@strickland.com');
+  });
+});

--- a/src/tests/resume/promptLibrary.test.ts
+++ b/src/tests/resume/promptLibrary.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for PromptLibrary
+ * Covers: template loading, getTemplate, fillTemplate variable substitution,
+ * addTemplate, listTemplates, exportTemplates, importTemplates
+ */
+
+import { PromptLibrary, PromptTemplate } from '../../resume/services/promptLibrary';
+
+describe('PromptLibrary — initialization', () => {
+  it('constructs without throwing', () => {
+    expect(() => new PromptLibrary()).not.toThrow();
+  });
+
+  it('loads exactly 4 default templates', () => {
+    const lib = new PromptLibrary();
+    expect(lib.listTemplates()).toHaveLength(4);
+  });
+
+  it('loads the expected default template ids', () => {
+    const lib = new PromptLibrary();
+    const ids = lib.listTemplates().map(t => t.id);
+    expect(ids).toContain('resume-tailor');
+    expect(ids).toContain('validation');
+    expect(ids).toContain('skills-extraction');
+    expect(ids).toContain('cover-letter');
+  });
+});
+
+// ─── getTemplate() ────────────────────────────────────────────────────────────
+
+describe('PromptLibrary.getTemplate()', () => {
+  let lib: PromptLibrary;
+  beforeEach(() => { lib = new PromptLibrary(); });
+
+  it('returns template object for "resume-tailor"', () => {
+    const t = lib.getTemplate('resume-tailor');
+    expect(t).toBeDefined();
+    expect(t?.id).toBe('resume-tailor');
+  });
+
+  it('returns template object for "validation"', () => {
+    const t = lib.getTemplate('validation');
+    expect(t).toBeDefined();
+    expect(t?.id).toBe('validation');
+  });
+
+  it('returns template object for "cover-letter"', () => {
+    const t = lib.getTemplate('cover-letter');
+    expect(t).toBeDefined();
+    expect(t?.id).toBe('cover-letter');
+  });
+
+  it('returns template object for "skills-extraction"', () => {
+    const t = lib.getTemplate('skills-extraction');
+    expect(t).toBeDefined();
+    expect(t?.id).toBe('skills-extraction');
+  });
+
+  it('returns undefined for unknown id', () => {
+    expect(lib.getTemplate('does-not-exist')).toBeUndefined();
+  });
+
+  it('returned template has required fields', () => {
+    const t = lib.getTemplate('resume-tailor')!;
+    expect(t.id).toBeTruthy();
+    expect(t.name).toBeTruthy();
+    expect(t.systemPrompt).toBeTruthy();
+    expect(t.userPromptTemplate).toBeTruthy();
+    expect(t.outputFormat).toBeTruthy();
+  });
+});
+
+// ─── fillTemplate() ──────────────────────────────────────────────────────────
+
+describe('PromptLibrary.fillTemplate()', () => {
+  let lib: PromptLibrary;
+
+  const customTemplate: PromptTemplate = {
+    id: 'test-template',
+    name: 'Test Template',
+    description: 'For unit tests',
+    systemPrompt: 'You are a test assistant.',
+    userPromptTemplate: 'Hello {name}, your task is {task}. Again: {name}.\n\n{outputFormat}',
+    outputFormat: 'Return plain text.',
+  };
+
+  beforeEach(() => {
+    lib = new PromptLibrary();
+    lib.addTemplate(customTemplate);
+  });
+
+  it('returns null for unknown template id', () => {
+    expect(lib.fillTemplate('nonexistent', {})).toBeNull();
+  });
+
+  it('returns object with system and user keys', () => {
+    const result = lib.fillTemplate('test-template', { name: 'Hank', task: 'review code' });
+    expect(result).toHaveProperty('system');
+    expect(result).toHaveProperty('user');
+  });
+
+  it('replaces a {variable} placeholder', () => {
+    const result = lib.fillTemplate('test-template', { name: 'Hank', task: 'review code' });
+    expect(result!.user).toContain('Hank');
+    expect(result!.user).toContain('review code');
+  });
+
+  it('replaces the same variable appearing multiple times', () => {
+    const result = lib.fillTemplate('test-template', { name: 'Hank', task: 'review code' });
+    // "Again: {name}" should also be replaced
+    const occurrences = (result!.user.match(/Hank/g) || []).length;
+    expect(occurrences).toBeGreaterThanOrEqual(2);
+  });
+
+  it('leaves system prompt unchanged', () => {
+    const result = lib.fillTemplate('test-template', { name: 'Hank', task: 'review code' });
+    expect(result!.system).toBe('You are a test assistant.');
+  });
+
+  it('appends outputFormat to user prompt', () => {
+    const result = lib.fillTemplate('test-template', { name: 'Hank', task: 'review code' });
+    expect(result!.user).toContain('Return plain text.');
+  });
+
+  it('does not leave unreplaced {outputFormat} placeholder when outputFormat exists', () => {
+    const result = lib.fillTemplate('test-template', { name: 'Hank', task: 'review code' });
+    expect(result!.user).not.toContain('{outputFormat}');
+  });
+
+  it('works with real resume-tailor template and expected variables', () => {
+    const result = lib.fillTemplate('resume-tailor', {
+      name: 'Hank Hill',
+      summary: 'Engineer',
+      workHistory: 'Strickland Propane | Engineer | 2020-Present | Arlen TX',
+      jobTitle: 'Senior Engineer',
+      company: 'Acme Corp',
+      jobPosting: 'We need an engineer',
+      numPositions: '1',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.user).toContain('Hank Hill');
+    expect(result!.user).toContain('Acme Corp');
+  });
+});
+
+// ─── addTemplate() ────────────────────────────────────────────────────────────
+
+describe('PromptLibrary.addTemplate()', () => {
+  it('adds a custom template retrievable by getTemplate()', () => {
+    const lib = new PromptLibrary();
+    const custom: PromptTemplate = {
+      id: 'custom-id', name: 'Custom', description: 'desc',
+      systemPrompt: 'sys', userPromptTemplate: 'user', outputFormat: 'out',
+    };
+    lib.addTemplate(custom);
+    expect(lib.getTemplate('custom-id')).toEqual(custom);
+  });
+
+  it('custom template appears in listTemplates()', () => {
+    const lib = new PromptLibrary();
+    const custom: PromptTemplate = {
+      id: 'my-custom', name: 'Mine', description: 'desc',
+      systemPrompt: 'sys', userPromptTemplate: 'user', outputFormat: 'out',
+    };
+    lib.addTemplate(custom);
+    const ids = lib.listTemplates().map(t => t.id);
+    expect(ids).toContain('my-custom');
+  });
+
+  it('can override an existing template by same id', () => {
+    const lib = new PromptLibrary();
+    const override: PromptTemplate = {
+      id: 'validation', name: 'Overridden', description: 'overridden',
+      systemPrompt: 'new sys', userPromptTemplate: 'new user', outputFormat: 'new out',
+    };
+    lib.addTemplate(override);
+    expect(lib.getTemplate('validation')!.name).toBe('Overridden');
+  });
+});
+
+// ─── exportTemplates() / importTemplates() ───────────────────────────────────
+
+describe('PromptLibrary.exportTemplates()', () => {
+  it('returns valid JSON string', () => {
+    const lib = new PromptLibrary();
+    expect(() => JSON.parse(lib.exportTemplates())).not.toThrow();
+  });
+
+  it('exported JSON contains all 4 default template ids', () => {
+    const lib = new PromptLibrary();
+    const parsed = JSON.parse(lib.exportTemplates()) as PromptTemplate[];
+    const ids = parsed.map(t => t.id);
+    expect(ids).toContain('resume-tailor');
+    expect(ids).toContain('validation');
+    expect(ids).toContain('cover-letter');
+    expect(ids).toContain('skills-extraction');
+  });
+});
+
+describe('PromptLibrary.importTemplates()', () => {
+  it('imports and makes templates available', () => {
+    const lib = new PromptLibrary();
+    const newTemplates: PromptTemplate[] = [{
+      id: 'imported-template', name: 'Imported', description: 'test',
+      systemPrompt: 'sys', userPromptTemplate: 'user', outputFormat: 'out',
+    }];
+    lib.importTemplates(JSON.stringify(newTemplates));
+    expect(lib.getTemplate('imported-template')).toBeDefined();
+  });
+
+  it('does not throw on invalid JSON', () => {
+    const lib = new PromptLibrary();
+    expect(() => lib.importTemplates('not valid json {')).not.toThrow();
+  });
+
+  it('round-trips: export then import produces parseable JSON with all default ids', () => {
+    const lib1 = new PromptLibrary();
+    const exported = lib1.exportTemplates();
+    const lib2 = new PromptLibrary();
+    lib2.importTemplates(exported);
+    // The exported JSON is valid and all 4 default ids survive the round-trip
+    const ids = lib2.listTemplates().map(t => t.id);
+    expect(ids).toContain('resume-tailor');
+    expect(ids).toContain('validation');
+    expect(ids).toContain('cover-letter');
+    expect(ids).toContain('skills-extraction');
+  });
+});

--- a/src/tests/resume/promptLibrary.test.ts
+++ b/src/tests/resume/promptLibrary.test.ts
@@ -6,6 +6,15 @@
 
 import { PromptLibrary, PromptTemplate } from '../../resume/services/promptLibrary';
 
+// Suppress console.error: importTemplates logs on invalid JSON as expected behavior.
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('PromptLibrary — initialization', () => {
   it('constructs without throwing', () => {
     expect(() => new PromptLibrary()).not.toThrow();

--- a/tsconfig.resume.json
+++ b/tsconfig.resume.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": false,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["jest", "node"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "src/resume/**/*",
+    "src/tests/resume/**/*",
+    "src/data/profileData.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

First-ever test coverage for the resume tailoring system in `src/resume/`.

**91 tests across 4 files, all passing. Existing 58 component tests unaffected.**

---

## What's Covered

| File | Tests | Covers |
|---|---|---|
| `ollamaService.test.ts` | 26 | Constructor, model alias resolution (5 aliases), `forTask()` routing (5 tasks), `isAvailable()`, `chat()`, `extractJobKeywords()` JSON parsing + fallbacks |
| `promptLibrary.test.ts` | 26 | Initialization, `getTemplate()`, `fillTemplate()` variable substitution, `addTemplate()`, `exportTemplates()`, `importTemplates()` |
| `llmValidator.test.ts` | 20 | `parseValidationResponse` via `validateResume()`: JSON parsing, code block stripping, issue/warning normalization, all fallback paths |
| `profileDataAdapter.test.ts` | 19 | `getProfileForResume()` with mocked `fs` + `profileData`, `calculateYearsOfExperience()` with frozen time, `getProfileAsText()` |

## Infrastructure

- **`jest.resume.config.cjs`** — separate Jest config with `testEnvironment: 'node'` (resume services are server-side, not jsdom)
- **`tsconfig.resume.json`** — separate tsconfig using `module: CommonJS` (NodeNext is incompatible with ts-jest); `src/resume/` is excluded from `tsconfig.app.json` so this was required
- **`package.json`** — added `test:resume` script; `jest.config.cjs` updated to ignore `src/tests/resume` (prevents double-run)

## Review Loop (Tier 3 — Standard)

This PR went through the full adversarial review loop before being opened:

**Iteration 1 — Adversarial review flagged 4 issues:**
1. **[Blocking]** `global.fetch` direct assignment not restored by `restoreAllMocks()` — potential flaky CI from cross-test mock leakage
2. **[Blocking]** Duplicate constructor test — same assertion twice, false confidence
3. **[Required]** `importTemplates` round-trip test asserted `length >= 4` (vacuously true regardless of bug)
4. **[Required]** `transformIgnorePatterns: ['node_modules/']` missing leading slash per Jest docs

**Iteration 1 — All 4 fixed:**
- Switched all `global.fetch = jest.fn()` to `jest.spyOn(global, 'fetch')` throughout `ollamaService.test.ts` — `restoreAllMocks()` now properly handles cleanup
- Removed duplicate constructor test; replaced with distinct assertion (accepts custom baseUrl)
- Replaced `>= 4` with explicit id-presence checks that verify round-trip fidelity
- Fixed `transformIgnorePatterns` → `['/node_modules/']`

**Iteration 2 — Both reviewers approved. PR opened.**

## Test Results

```
npm run test:resume  →  91 passed, 4 suites
npm test             →  58 passed, 5 suites  (unchanged)
```