### PR TITLE
Fix Python interpreter resolution in ingestion pipeline

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -9,12 +9,25 @@ node --version  # should be >= 20.11.1
 npm --version   # should be >= 10.2.4
 ```
 
-**Python** ≥ 3.9 is required only if you plan to run the Python job ingest script:
+**Python 3.13** is required only if you plan to run the Python job ingest script.
+jobspy's regex wheel does not build on Python 3.14+, so the system Python (which
+may be newer) can silently break ingestion. The recommended setup is a dedicated
+venv at `~/.venv/jobhunter-sys` using Python 3.13:
 
 ```bash
-python3 --version  # should be >= 3.9
-pip3 install -r src/job-hunter/sources/requirements.txt
+# One-time setup — create the venv with Python 3.13 and install dependencies
+python3.13 -m venv ~/.venv/jobhunter-sys
+~/.venv/jobhunter-sys/bin/pip install -r src/job-hunter/sources/requirements.txt
 ```
+
+`ingestion.ts` resolves the interpreter in this order:
+1. `INGEST_PYTHON` env var (if set) — use this to point at any interpreter explicitly
+2. `~/.venv/jobhunter-sys/bin/python3` (if it exists on disk) — preferred
+3. `python3` system fallback (may be incompatible with jobspy on newer OS versions)
+
+A missing venv is handled gracefully — ingestion falls back to `python3` rather
+than crashing. If jobspy fails to import, set `INGEST_PYTHON` to a known-good 3.13
+interpreter.
 
 **Environment variables** — export these in your shell before running the job-hunter pipeline (e.g. add to `~/.bashrc` / `~/.zshrc`, or `export VAR=value` in your terminal):
 
@@ -24,6 +37,7 @@ pip3 install -r src/job-hunter/sources/requirements.txt
 | `TELEGRAM_BOT_TOKEN` | Telegram bot token for job notifications |
 | `TELEGRAM_CHAT_ID` | Telegram chat ID for job notifications |
 | `JOB_HUNTER_DB` | Path to the SQLite database file (e.g. `./job-hunter.db`) |
+| `INGEST_PYTHON` | Override the Python interpreter used by `ingest.py` (e.g. `/usr/local/bin/python3.13`) |
 
 The portfolio site itself has no required env vars; the above are only needed to run the job-hunter pipeline.
 

--- a/src/job-hunter/ingestion.ts
+++ b/src/job-hunter/ingestion.ts
@@ -83,14 +83,9 @@ export async function ingestJobs(
 }
 
 /**
- * Returns the Python interpreter to use for running ingest.py.
- * Resolution order:
- *   1. INGEST_PYTHON env var (if set)
- *   2. ~/.venv/jobhunter-sys/bin/python3 (if present on disk)
- *   3. 'python3' system fallback
- *
- * The venv is preferred because jobspy's regex wheel fails to build on
- * Python 3.14+; the venv is expected to use Python 3.13.
+ * Resolves the Python interpreter for ingest.py: INGEST_PYTHON env var,
+ * then ~/.venv/jobhunter-sys/bin/python3, then 'python3' system fallback.
+ * The venv is preferred because jobspy's regex wheel fails on Python 3.14+.
  */
 export function resolveInterpreter(): string {
   if (process.env.INGEST_PYTHON) {

--- a/src/job-hunter/ingestion.ts
+++ b/src/job-hunter/ingestion.ts
@@ -1,4 +1,6 @@
 import { execFile } from 'child_process';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import type Database from 'better-sqlite3';
 import type { JobInput } from './db/types';
@@ -81,6 +83,33 @@ export async function ingestJobs(
 }
 
 /**
+ * Returns the Python interpreter to use for running ingest.py.
+ * Resolution order:
+ *   1. INGEST_PYTHON env var (if set)
+ *   2. ~/.venv/jobhunter-sys/bin/python3 (if present on disk)
+ *   3. 'python3' system fallback
+ *
+ * The venv is preferred because jobspy's regex wheel fails to build on
+ * Python 3.14+; the venv is expected to use Python 3.13.
+ */
+export function resolveInterpreter(): string {
+  if (process.env.INGEST_PYTHON) {
+    return process.env.INGEST_PYTHON;
+  }
+  const venvPython = path.join(
+    os.homedir(),
+    '.venv',
+    'jobhunter-sys',
+    'bin',
+    'python3',
+  );
+  if (fs.existsSync(venvPython)) {
+    return venvPython;
+  }
+  return 'python3';
+}
+
+/**
  * Run the Python ingest.py scraper as a subprocess, passing the database path
  * as the first argument. Parses "Inserted X, skipped Y" from stdout and
  * returns the counts. Propagates non-zero exit as a rejection.
@@ -90,7 +119,8 @@ export async function runIngestion(
   dbPath: string,
 ): Promise<IngestionResult> {
   const scriptPath = path.join(__dirname, 'sources', 'ingest.py');
-  const stdout = await execFileAsync('python3', [scriptPath, dbPath]);
+  const interpreter = resolveInterpreter();
+  const stdout = await execFileAsync(interpreter, [scriptPath, dbPath]);
 
   const match = stdout.match(/Inserted (\d+), skipped (\d+)/);
   if (!match) {

--- a/src/job-hunter/sources/requirements.txt
+++ b/src/job-hunter/sources/requirements.txt
@@ -1,1 +1,3 @@
+# Requires Python 3.13 — the jobspy regex wheel fails to build on Python 3.14+.
+# Use the dedicated venv: ~/.venv/jobhunter-sys (see BUILD.md).
 python-jobspy>=1.1.80

--- a/src/tests/job-hunter/ingestion.test.ts
+++ b/src/tests/job-hunter/ingestion.test.ts
@@ -14,11 +14,19 @@ jest.mock('child_process', () => ({
   execFile: jest.fn(),
 }));
 
+jest.mock('fs', () => ({
+  ...jest.requireActual<typeof import('fs')>('fs'),
+  existsSync: jest.fn(),
+}));
+
 import { execFile } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import path from 'path';
 import Database from 'better-sqlite3';
 import { runMigrations } from '../../job-hunter/db/migrations';
 import { blacklistJob, listJobs } from '../../job-hunter/db/repository';
-import { ingestJobs, runIngestion } from '../../job-hunter/ingestion';
+import { ingestJobs, runIngestion, resolveInterpreter } from '../../job-hunter/ingestion';
 import type { NormalizedJob } from '../../job-hunter/ingestion';
 
 const mockExecFile = execFile as jest.MockedFunction<typeof execFile>;
@@ -327,5 +335,65 @@ describe('runIngestion()', () => {
 
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+
+  it('Given INGEST_PYTHON is set, When runIngestion is called, Then that interpreter is passed to execFile', async () => {
+    const db = makeDb();
+    process.env.INGEST_PYTHON = '/custom/python3.13';
+    mockExecFileSuccess('Inserted 2, skipped 1\n');
+
+    try {
+      await runIngestion(db, 'test.db');
+      expect(mockExecFile).toHaveBeenCalledWith(
+        '/custom/python3.13',
+        expect.any(Array),
+        expect.any(Function),
+      );
+    } finally {
+      delete process.env.INGEST_PYTHON;
+    }
+  });
+});
+
+// ─── resolveInterpreter() ─────────────────────────────────────────────────────
+
+const mockExistsSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+
+describe('resolveInterpreter()', () => {
+  const expectedVenvPath = path.join(
+    os.homedir(),
+    '.venv',
+    'jobhunter-sys',
+    'bin',
+    'python3',
+  );
+
+  beforeEach(() => {
+    delete process.env.INGEST_PYTHON;
+    mockExistsSync.mockReset();
+  });
+
+  it('Given INGEST_PYTHON is set, When resolveInterpreter is called, Then returns the env var value', () => {
+    process.env.INGEST_PYTHON = '/usr/local/bin/python3.13';
+    expect(resolveInterpreter()).toBe('/usr/local/bin/python3.13');
+  });
+
+  it('Given INGEST_PYTHON is set and venv exists, When resolveInterpreter is called, Then env var takes priority and existsSync is not called', () => {
+    process.env.INGEST_PYTHON = '/custom/python';
+    mockExistsSync.mockReturnValue(true);
+    expect(resolveInterpreter()).toBe('/custom/python');
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+
+  it('Given INGEST_PYTHON is not set and venv exists, When resolveInterpreter is called, Then returns the venv path', () => {
+    mockExistsSync.mockReturnValue(true);
+    const result = resolveInterpreter();
+    expect(result).toBe(expectedVenvPath);
+    expect(mockExistsSync).toHaveBeenCalledWith(expectedVenvPath);
+  });
+
+  it('Given INGEST_PYTHON is not set and venv does not exist, When resolveInterpreter is called, Then falls back to python3', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(resolveInterpreter()).toBe('python3');
   });
 });


### PR DESCRIPTION
Closes droplet po-ycjoz.

Fixes Python interpreter resolution in ingestion.ts to use (1) INGEST_PYTHON env var if set, (2) ~/.venv/jobhunter-sys/bin/python3 if exists, (3) fall back to 'python3'. Updated BUILD.md and requirements.txt with venv setup documentation.