### PR TITLE
Tune job sources for director/VP/head-of-engineering signal quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ A backend subsystem for automating remote job discovery, scoring, and applicatio
 ### Features
 - **Job Discovery**: Scrapes jobs for 4 target roles (Director of Engineering, Senior Engineering Manager, VP of Engineering, VP of QA)
 - **Remote Job Filtering**: Automatically filters for remote positions only
-- **Multi-Source Scraping**: Searches across Indeed, LinkedIn, ZipRecruiter, and Google simultaneously
+- **Multi-Source Scraping**: Searches across LinkedIn and ZipRecruiter
 - **SQLite Database**: Persistent storage for jobs, scores, approvals, and application tracking
 - **AI-Powered Scoring**: Claude API integration for fit-scoring each job
 - **Telegram Notifications**: Sends new high-scoring jobs to Telegram with approve/deny buttons
@@ -142,7 +142,7 @@ python3 src/job-hunter/sources/ingest.py
 
 The script:
 
-Alternatively, use the Python script to scrape jobs directly from jobspy-supported job boards (Indeed, LinkedIn, ZipRecruiter, Google):
+Alternatively, use the Python script to scrape jobs directly from jobspy-supported job boards (LinkedIn, ZipRecruiter):
 
 ```bash
 # Install Python dependencies (one-time setup)
@@ -158,8 +158,8 @@ python3 src/job-hunter/sources/ingest.py
 
 The script:
 - Scrapes jobs for 4 target roles: Director of Engineering, Senior Engineering Manager, VP of Engineering, VP of QA
-- Searches across Indeed, LinkedIn, ZipRecruiter, and Google
-- Filters for remote positions posted in the last 48 hours with 25 results per source per role
+- Searches across LinkedIn and ZipRecruiter
+- Filters for remote positions posted in the last 48 hours with 40 results per role
 - Writes one line to stdout on completion: `Inserted X, skipped Y`
 - Per-source errors are logged to stderr and don't halt the script — continues with other sources
 - Skips blacklisted jobs and duplicate (source, external_id) pairs

--- a/openclaw/portfoliowebsite/SKILL.md
+++ b/openclaw/portfoliowebsite/SKILL.md
@@ -64,7 +64,7 @@ npx tsc --project src/resume/tsconfig.json
 ## Job Hunter Pipeline
 
 **Repo location:** `src/job-hunter/`
-**Source:** Python ingest.py script using jobspy (Indeed, LinkedIn, ZipRecruiter, Google)
+**Source:** Python ingest.py script using jobspy (LinkedIn, ZipRecruiter)
 **Target roles:** Director of Engineering, Senior Engineering Manager, VP of Engineering, VP of QA
 
 The pipeline runs on lobsterdog (not Netlify — that's a static site). Required env vars for full pipeline: `ANTHROPIC_API_KEY`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`.

--- a/src/job-hunter/db/types.ts
+++ b/src/job-hunter/db/types.ts
@@ -1,4 +1,4 @@
-export type AtsType = 'indeed' | 'linkedin' | 'zip_recruiter' | 'google' | 'unknown';
+export type AtsType = 'linkedin' | 'zip_recruiter' | 'unknown';
 export type ApprovalStatus = 'pending' | 'approved' | 'denied';
 export type ApplicationMethod = 'greenhouse' | 'lever' | 'manual';
 

--- a/src/job-hunter/sources/ingest.py
+++ b/src/job-hunter/sources/ingest.py
@@ -110,10 +110,10 @@ def ingest(db_path: str) -> tuple[int, int]:
         for role in ROLES:
             try:
                 df = scrape_jobs(
-                    site_name=['indeed', 'linkedin', 'zip_recruiter', 'google'],
+                    site_name=['linkedin', 'zip_recruiter'],
                     search_term=role,
                     location='United States',
-                    results_wanted=25,
+                    results_wanted=40,
                     hours_old=48,
                     is_remote=True,
                     linkedin_fetch_description=True,

--- a/src/tests/job-hunter/repository.test.ts
+++ b/src/tests/job-hunter/repository.test.ts
@@ -46,7 +46,7 @@ const jobA = {
 
 const jobB = {
   source: 'indeed',
-  ats_type: 'indeed' as const,
+  ats_type: 'unknown' as const,
   external_id: 'job-002',
   title: 'Senior Engineer',
   company: 'Globex',

--- a/src/tests/job-hunter/test_ingest.py
+++ b/src/tests/job-hunter/test_ingest.py
@@ -403,8 +403,6 @@ class TestIngest:
             assert set(site_name) == {'linkedin', 'zip_recruiter'}, (
                 f'Expected only linkedin and zip_recruiter, got {site_name}'
             )
-            assert 'indeed' not in site_name
-            assert 'google' not in site_name
 
     def test_scrape_jobs_called_with_results_wanted_40(self, tmp_path):
         """Given ingest is called, When scrape_jobs is invoked for each role,

--- a/src/tests/job-hunter/test_ingest.py
+++ b/src/tests/job-hunter/test_ingest.py
@@ -391,6 +391,31 @@ class TestIngest:
 
         assert inserted == 1
 
+    def test_scrape_jobs_called_with_linkedin_and_zip_recruiter_only(self, tmp_path):
+        """Given ingest is called, When scrape_jobs is invoked for each role,
+        Then site_name contains only linkedin and zip_recruiter."""
+        db_path = str(tmp_path / 'test.db')
+        with patch('ingest.scrape_jobs', return_value=pd.DataFrame()) as mock_scrape:
+            ingest(db_path)
+        assert mock_scrape.call_count > 0
+        for call in mock_scrape.call_args_list:
+            site_name = call.kwargs['site_name']
+            assert set(site_name) == {'linkedin', 'zip_recruiter'}, (
+                f'Expected only linkedin and zip_recruiter, got {site_name}'
+            )
+            assert 'indeed' not in site_name
+            assert 'google' not in site_name
+
+    def test_scrape_jobs_called_with_results_wanted_40(self, tmp_path):
+        """Given ingest is called, When scrape_jobs is invoked for each role,
+        Then results_wanted is 40."""
+        db_path = str(tmp_path / 'test.db')
+        with patch('ingest.scrape_jobs', return_value=pd.DataFrame()) as mock_scrape:
+            ingest(db_path)
+        assert mock_scrape.call_count > 0
+        for call in mock_scrape.call_args_list:
+            assert call.kwargs['results_wanted'] == 40
+
     def test_busy_timeout_pragma_is_set_on_ingest_connection(self, tmp_path):
         """When ingest() opens its SQLite connection, Then it executes PRAGMA busy_timeout = 5000."""
         from unittest.mock import MagicMock, call, patch as mock_patch


### PR DESCRIPTION
Closes droplet po-v2a9e.

Changes:
- Update ingest.py sources to ['linkedin', 'zip_recruiter']
- Increase linkedin results_wanted to 40
- Narrow AtsType in db/types.ts to exclude 'indeed' and 'google'
- Updated documentation in README.md and SKILL.md
- Verified by security and QA